### PR TITLE
Add CPU support and device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,24 @@ lit-inpainting --input_image T1w.nii.gz --mask_image lesion_mask.nii.gz --output
 **Note:** If you skip the `lit-download-models` step, models will be automatically downloaded on first use.
 
 
+## Expected Runtimes
+
+Runtimes below are for a typical whole-brain T1w volume (1 mm isotropic), measured with neuroLIT v0.6.0:
+
+| Hardware | Runtime |
+|---|---|
+| NVIDIA GeForce RTX 5070 Ti (16 GB) | ~17 minutes |
+| Intel Xeon w5-2465X (CPU only) | ~5.5 hours |
+
+GPU is strongly recommended for interactive use. CPU is feasible for batch/overnight processing.
+
 ## Integration with FreeSurfer/FastSurfer
 
 neuroLIT is being integrated into [FastSurfer](https://github.com/deep-mi/FastSurfer) for whole brain segmentation and cortical surface reconstruction of images with lesions. 
 
 For standalone usage with FreeSurfer/FastSurfer, neuroLIT provides post-processing scripts for integrating lesions into FastSurfer/FreeSurfer outputs. We recommend using the unified `lit-postprocessing` script which handles mapping the lesion mask to multiple segmentation files, running volume statistics (segstats), and performing surface masking.
 
-### Postprocessing (available in developement version)
+### Postprocessing (available in development version)
 
 This script modifies FastSurfer/FreeSurfer segmentations and surface annotation files, and the corresponading statistics (.stats) files.
 

--- a/neurolit/cli.py
+++ b/neurolit/cli.py
@@ -28,6 +28,12 @@ def run_lit():
     
     # Optional arguments
     parser.add_argument("--dilate", type=int, default=0, help="Number of times to dilate the lesion mask (default: 0)")
+    parser.add_argument(
+        "--device",
+        choices=["auto", "cpu", "cuda"],
+        default="auto",
+        help="Inference device to use (default: auto)",
+    )
     
     # Other arguments
     parser.add_argument("-h", "--help", action="store_true", help="Show help message and exit")
@@ -43,6 +49,7 @@ def run_lit():
         print("  -o, --sd, --out_dir, --output_directory : Output directory")
         print("Optional arguments:")
         print("  --dilate              : Number of times to dilate the lesion mask (default: 0)")
+        print("  --device              : Inference device: auto, cpu, or cuda (default: auto)")
         print("Other arguments:")
         print("  -v, --version         : Print version number and exit")
         print("  -h, --help            : Show help message and exit")
@@ -102,7 +109,8 @@ def run_lit():
                 "--checkpoint_axial", str(ckpt_axial),
                 "--checkpoint_sagittal", str(ckpt_sagittal),
                 "--checkpoint_coronal", str(ckpt_coronal),
-                "--dilate", str(args.dilate)
+                "--dilate", str(args.dilate),
+                "--device", args.device,
             ]
             
             # Forward any unknown arguments

--- a/neurolit/inpaint_image.py
+++ b/neurolit/inpaint_image.py
@@ -58,6 +58,31 @@ VolumeSlice = tuple[int | slice, ...]
 AffineMatrix = NDArray[np.float64]
 
 
+def resolve_inference_device(device: str) -> torch.device:
+    """Resolve the requested inference device.
+
+    Parameters
+    ----------
+    device : str
+        Requested device name: ``"auto"``, ``"cpu"``, or ``"cuda"``.
+
+    Returns
+    -------
+    torch.device
+        Resolved torch device.
+    """
+    normalized_device = device.lower()
+    if normalized_device == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if normalized_device == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested for inference, but no CUDA device is available.")
+        return torch.device("cuda")
+    if normalized_device == "cpu":
+        return torch.device("cpu")
+    raise ValueError(f"Unsupported device '{device}'. Expected one of: auto, cpu, cuda.")
+
+
 def dilate_mask(mask: torch.Tensor, num_iterations: int, kernel_size: int = 3) -> torch.Tensor:
     """Dilate a binary mask using repeated max pooling.
 
@@ -169,7 +194,7 @@ def inpaint_volume(
     slice_input: bool = True,
     SAVE_VOLUMES: bool = True,
     SAVE_IMAGES: bool = True,
-    device: str = "cuda",
+    device: torch.device | str = "cuda",
     DDIM: bool = False,
     val_image_nib: NiftiImage | None = None
 ) -> torch.Tensor:
@@ -284,7 +309,7 @@ def inpaint_volume(
     )
 
     #import pdb; pdb.set_trace()
-    with torch.inference_mode(), autocast(enabled=True, device_type='cuda'):
+    with torch.inference_mode(), autocast(device_type=device.type, enabled=device.type == "cuda"):
         val_image_inpainted = Inpainter(
             mask=mask[0],
             image_masked=val_image_masked[0],
@@ -347,22 +372,31 @@ def main(argv=None):
     parser.add_argument('-c_sagittal', '--checkpoint_sagittal',
                         type=str, help='checkpoint to load for inference in sagittal plane',
                         default=None, required=False)
+    parser.add_argument(
+        '--device',
+        type=str,
+        choices=['auto', 'cpu', 'cuda'],
+        default='auto',
+        help='Inference device to use (default: auto)',
+    )
 
     args = parser.parse_args(argv)
 
 
     # load models
+    device = resolve_inference_device(args.device)
+    logger.info(f'Using inference device: {device.type}')
+
     model_state_dicts = {}
     if args.checkpoint_coronal is not None:
-        model_state_dicts['coronal'] = torch.load(args.checkpoint_coronal, weights_only=True)
+        model_state_dicts['coronal'] = torch.load(args.checkpoint_coronal, map_location=device, weights_only=True)
     if args.checkpoint_axial is not None:
-        model_state_dicts['axial'] = torch.load(args.checkpoint_axial, weights_only=True)
+        model_state_dicts['axial'] = torch.load(args.checkpoint_axial, map_location=device, weights_only=True)
     if args.checkpoint_sagittal is not None:
-        model_state_dicts['sagittal'] = torch.load(args.checkpoint_sagittal, weights_only=True)
+        model_state_dicts['sagittal'] = torch.load(args.checkpoint_sagittal, map_location=device, weights_only=True)
 
 
     # setup model
-    device = torch.device("cuda") if torch.cuda.is_available() else "cpu"
     SLICE_THICKNESS = 7
     # make model out of weights only
     model_dict = {}

--- a/neurolit/scripts/run_lit_containerized.sh
+++ b/neurolit/scripts/run_lit_containerized.sh
@@ -18,6 +18,10 @@ FLAGS:
       Print the version number and exit
   --gpus <gpus>
       GPUs to use. Default: all
+  --device <auto|cpu|cuda>
+      Inference device inside the container. Default: auto
+  --cpu
+      Shorthand for --device cpu
   -i, --input_image <input_image>
       Path to the input T1w volume
   -m, --mask_image <mask_image>
@@ -59,6 +63,7 @@ DOCKER_REPO="deepmi/lit"
 # Initialize variables
 USE_SINGULARITY=false
 VERSION=""
+DEVICE="auto"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -70,6 +75,24 @@ while [[ $# -gt 0 ]]; do
       fi
       GPUS="$2"
       shift 2
+      ;;
+    --device)
+      if [[ -z "$2" || "$2" == -* ]]; then
+        echo "Error: --device requires a value"
+        usage
+        exit 1
+      fi
+      if [[ "$2" != "auto" && "$2" != "cpu" && "$2" != "cuda" ]]; then
+        echo "Error: --device must be one of: auto, cpu, cuda"
+        usage
+        exit 1
+      fi
+      DEVICE="$2"
+      shift 2
+      ;;
+    --cpu)
+      DEVICE="cpu"
+      shift
       ;;
     -i|--input_image)
       if [[ -z "$2" || "$2" == -* ]]; then
@@ -196,6 +219,16 @@ if [ -z "$GPUS" ]; then
   GPUS="all"
 fi
 
+if [[ "$DEVICE" == "auto" ]]; then
+  if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+    RESOLVED_DEVICE="cuda"
+  else
+    RESOLVED_DEVICE="cpu"
+  fi
+else
+  RESOLVED_DEVICE="$DEVICE"
+fi
+
 # Run command based on the containerization tool
 if [ "$USE_SINGULARITY" = true ]; then
   if [ ! -f "$PROJ_DIR/containerization/deepmi_lit.simg" ]; then
@@ -208,18 +241,29 @@ if [ "$USE_SINGULARITY" = true ]; then
     exit 1
   fi
 
-  singularity exec --nv \
+  SINGULARITY_ARGS=()
+  if [[ "$RESOLVED_DEVICE" == "cuda" ]]; then
+    SINGULARITY_ARGS+=(--nv)
+  fi
+
+  singularity exec "${SINGULARITY_ARGS[@]}" \
     -B "${INPUT_IMAGE}":"${INPUT_IMAGE}":ro \
     -B "${MASK_IMAGE}":"${MASK_IMAGE}":ro \
     -B "${OUT_DIR}":"${OUT_DIR}" \
     $PROJ_DIR/containerization/deepmi_lit.simg \
-    lit-inpainting -i "${INPUT_IMAGE}" -m "${MASK_IMAGE}" -o "${OUT_DIR}" "${POSITIONAL_ARGS[@]}"
+    lit-inpainting -i "${INPUT_IMAGE}" -m "${MASK_IMAGE}" -o "${OUT_DIR}" --device "${RESOLVED_DEVICE}" "${POSITIONAL_ARGS[@]}"
 else
-  docker run --gpus "device=$GPUS" --ipc=host \
-    --ulimit memlock=-1 --ulimit stack=67108864 --rm \
-    -v "${INPUT_IMAGE}":"${INPUT_IMAGE}":ro \
-    -v "${MASK_IMAGE}":"${MASK_IMAGE}":ro \
-    -v "${OUT_DIR}":"${OUT_DIR}" \
-    -u "$(id -u):$(id -g)" \
-    ${IMAGE} -i "${INPUT_IMAGE}" -m "${MASK_IMAGE}" -o "${OUT_DIR}" "${POSITIONAL_ARGS[@]}"
+  DOCKER_ARGS=(run --ipc=host
+    --ulimit memlock=-1 --ulimit stack=67108864 --rm
+    -v "${INPUT_IMAGE}":"${INPUT_IMAGE}":ro
+    -v "${MASK_IMAGE}":"${MASK_IMAGE}":ro
+    -v "${OUT_DIR}":"${OUT_DIR}"
+    -u "$(id -u):$(id -g)")
+
+  if [[ "$RESOLVED_DEVICE" == "cuda" ]]; then
+    DOCKER_ARGS+=(--gpus "device=$GPUS")
+  fi
+
+  docker "${DOCKER_ARGS[@]}" \
+    ${IMAGE} -i "${INPUT_IMAGE}" -m "${MASK_IMAGE}" -o "${OUT_DIR}" --device "${RESOLVED_DEVICE}" "${POSITIONAL_ARGS[@]}"
 fi

--- a/neurolit/tests/test_cli_help.py
+++ b/neurolit/tests/test_cli_help.py
@@ -1,6 +1,10 @@
 import subprocess
 import sys
 
+import pytest
+
+from neurolit.inpaint_image import resolve_inference_device
+
 
 def run_help_test(module_path):
     """Helper to run --help on a module and check exit code."""
@@ -16,7 +20,14 @@ def test_lit_inpainting_help():
     """Test lit-inpainting (neurolit.cli) help."""
     # Note: lit-inpainting entrypoint calls neurolit.cli:run_lit.
     # Testing the module directly:
-    run_help_test("neurolit.cli")
+    result = subprocess.run(
+        [sys.executable, "-m", "neurolit.cli", "--help"],
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0
+    assert "--device" in result.stdout
+    assert "auto, cpu, or cuda" in result.stdout
 
 def test_lesion_to_segmentation_help():
     """Test lit-lesion-to-segmentation help."""
@@ -25,3 +36,22 @@ def test_lesion_to_segmentation_help():
 def test_lesion_to_surface_help():
     """Test lit-lesion-to-surface help."""
     run_help_test("neurolit.postprocessing.lesion_to_surface")
+
+
+def test_resolve_inference_device_auto_prefers_cuda(monkeypatch):
+    """Auto should resolve to CUDA when available."""
+    monkeypatch.setattr("torch.cuda.is_available", lambda: True)
+    assert resolve_inference_device("auto").type == "cuda"
+
+
+def test_resolve_inference_device_auto_falls_back_to_cpu(monkeypatch):
+    """Auto should resolve to CPU when CUDA is unavailable."""
+    monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+    assert resolve_inference_device("auto").type == "cpu"
+
+
+def test_resolve_inference_device_rejects_unavailable_cuda(monkeypatch):
+    """Explicit CUDA should fail when no CUDA device is available."""
+    monkeypatch.setattr("torch.cuda.is_available", lambda: False)
+    with pytest.raises(RuntimeError, match="CUDA was requested"):
+        resolve_inference_device("cuda")


### PR DESCRIPTION
- Add --device flag (auto/cpu/cuda) to lit-inpainting CLI, inpaint_image.py, and run_lit_containerized.sh
- Fix autocast to use correct device_type on CPU
- Load checkpoints with map_location to avoid GPU-only loading
- Skip --gpus/--nv flags in container when running on CPU
- Fix bug: --device was parsed in cli.py but never forwarded to inpaint_main
- Add expected runtimes table to README (RTX 5070 Ti ~17 min, Xeon w5-2465X ~5.5 h)