### PR TITLE
Release/neurolit 0.6.1 fastsurfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ pip install neurolit
 lit-inpainting --input_image T1w.nii.gz --lesion_mask lesion_mask.nii.gz --output_directory output_directory
 ```
 
-When preparing a FastSurfer subject directory directly, add `--fastsurfer_dir`. This keeps the
-internal LIT work files under `inpainting/` and also writes FastSurfer-style convenience outputs
-such as `mri/inpainted.lit.nii.gz` and `mri/orig/mask.lit.nii.gz`.
+When preparing a FastSurfer subject directory directly, add `--fastsurfer_dir`. This writes the
+LIT outputs directly into the FastSurfer subject structure, including `mri/inpainted.lit.nii.gz`,
+the processed mask at `mri/mask.lit.nii.gz`, and the original input mask at
+`mri/orig/mask.lit.nii.gz`.
 
 ## How to run neuroLIT
 
@@ -70,9 +71,14 @@ The outputs will be placed in the output directory in the folder inpainting_volu
 - The (dilated) mask used for inpainting in the same space as the input image (`inpainting_mask.nii.gz`)
 - The conformed original image (`inpainting_original_image.nii.gz`)
 
-With `--fastsurfer_dir`, these same working files are written under `inpainting/inpainting_volumes/`
-inside the FastSurfer subject directory, and public convenience copies are also created at
-`mri/inpainted.lit.nii.gz` and `mri/orig/mask.lit.nii.gz`.
+With `--fastsurfer_dir`, these outputs are integrated into the FastSurfer subject directory instead:
+
+- `mri/inpainted.lit.nii.gz`
+- `mri/mask.lit.nii.gz`
+- `mri/orig/mask.lit.nii.gz`
+- `mri/orig/inpainting_original_image.lit.nii.gz`
+- `mri/orig/inpainting_masked_image.lit.nii.gz`
+- `scripts/inpainting_*.lit.png`
 
 We recommend performing dilation, since undersegmentation can negatively impact the performance of the inpainting, while oversegmentation should not have significant impact.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ pip install neurolit
 lit-inpainting --input_image T1w.nii.gz --lesion_mask lesion_mask.nii.gz --output_directory output_directory
 ```
 
+When preparing a FastSurfer subject directory directly, add `--fastsurfer_dir`. This keeps the
+internal LIT work files under `inpainting/` and also writes FastSurfer-style convenience outputs
+such as `mri/inpainted.lit.nii.gz` and `mri/orig/mask.lit.nii.gz`.
+
 ## How to run neuroLIT
 
 We recommend using containerization in combination with the [neurolit/scripts/run_lit_containerized.sh](neurolit/scripts/run_lit_containerized.sh) wrapper script.
@@ -65,6 +69,10 @@ The outputs will be placed in the output directory in the folder inpainting_volu
 - The inpainted T1w image (`inpainting_result.nii.gz`)
 - The (dilated) mask used for inpainting in the same space as the input image (`inpainting_mask.nii.gz`)
 - The conformed original image (`inpainting_original_image.nii.gz`)
+
+With `--fastsurfer_dir`, these same working files are written under `inpainting/inpainting_volumes/`
+inside the FastSurfer subject directory, and public convenience copies are also created at
+`mri/inpainted.lit.nii.gz` and `mri/orig/mask.lit.nii.gz`.
 
 We recommend performing dilation, since undersegmentation can negatively impact the performance of the inpainting, while oversegmentation should not have significant impact.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ lit-inpainting --input_image T1w.nii.gz --lesion_mask lesion_mask.nii.gz --outpu
 
 ## Expected Runtimes
 
-Runtimes below are for a typical whole-brain T1w volume (1 mm isotropic), measured with neuroLIT v0.6.0:
+Runtimes below are for a typical whole-brain T1w volume (1 mm isotropic), measured with neuroLIT v0.6.1:
 
 | Hardware | Runtime |
 |---|---|

--- a/doc/api/cli.rst
+++ b/doc/api/cli.rst
@@ -35,6 +35,7 @@ Entry point for the main ``lit-inpainting`` command. This is the primary interfa
 - ``--mask_image``: Path to lesion mask
 - ``--output_directory``: Output directory path
 - ``--dilate``: Number of dilation iterations (default: 0)
+- ``--fastsurfer_dir``: Treat the output directory as a FastSurfer subject directory
 - ``--device``: Device to use (cuda/cpu)
 
 Examples
@@ -75,4 +76,3 @@ Programmatic Usage
    
    result = subprocess.run(cmd, capture_output=True, text=True)
    print(result.stdout)
-

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -39,6 +39,10 @@ If you installed via pip:
        --output_directory output_directory \\
        --dilate 2
 
+If the output directory is a FastSurfer subject directory, add ``--fastsurfer_dir`` to keep the
+internal LIT files under ``inpainting/`` while also creating public FastSurfer-style outputs such
+as ``mri/inpainted.lit.nii.gz`` and ``mri/orig/mask.lit.nii.gz``.
+
 Mask Dilation
 ~~~~~~~~~~~~~
 
@@ -72,6 +76,10 @@ File Structure
        ├── inpainting_result.nii.gz
        ├── inpainting_mask.nii.gz
        └── inpainting_original_image.nii.gz
+
+With ``--fastsurfer_dir``, the same working files are written under ``inpainting/inpainting_volumes/``
+inside the subject directory and convenience copies are also created at
+``mri/inpainted.lit.nii.gz`` and ``mri/orig/mask.lit.nii.gz``.
 
 .. note::
    If the source image was isotropic, the output images will have the same resolution as the input image. The area outside of the lesion mask is preserved, except for robust rescaling of intensity values.
@@ -154,6 +162,7 @@ Main command to run the neuroLIT inpainting.
      -m, --lesion_mask PATH                          Path to lesion mask [required]
      -o, --sd / --out_dir / --output_directory PATH  Output directory [required]
      --dilate INTEGER                                Number of dilation iterations [default: 0]
+     --fastsurfer_dir                                Treat output_directory as a FastSurfer subject directory
      --device [auto|cpu|cuda]                        Inference device [default: auto]
      --batch_size INTEGER                            Slices per GPU batch [default: 8]; reduce to lower GPU memory usage
      -h, --help                                      Show this message and exit

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -39,9 +39,10 @@ If you installed via pip:
        --output_directory output_directory \\
        --dilate 2
 
-If the output directory is a FastSurfer subject directory, add ``--fastsurfer_dir`` to keep the
-internal LIT files under ``inpainting/`` while also creating public FastSurfer-style outputs such
-as ``mri/inpainted.lit.nii.gz`` and ``mri/orig/mask.lit.nii.gz``.
+If the output directory is a FastSurfer subject directory, add ``--fastsurfer_dir`` to integrate
+the outputs directly into the FastSurfer subject structure. In this mode, the inpainted image is
+written to ``mri/inpainted.lit.nii.gz``, the processed mask to ``mri/mask.lit.nii.gz``, and the
+original input mask to ``mri/orig/mask.lit.nii.gz``.
 
 Mask Dilation
 ~~~~~~~~~~~~~
@@ -77,9 +78,21 @@ File Structure
        ├── inpainting_mask.nii.gz
        └── inpainting_original_image.nii.gz
 
-With ``--fastsurfer_dir``, the same working files are written under ``inpainting/inpainting_volumes/``
-inside the subject directory and convenience copies are also created at
-``mri/inpainted.lit.nii.gz`` and ``mri/orig/mask.lit.nii.gz``.
+With ``--fastsurfer_dir``, these outputs are instead integrated into the FastSurfer subject
+directory, for example:
+
+.. code-block:: text
+
+   subject_directory/
+   ├── mri/
+   │   ├── inpainted.lit.nii.gz
+   │   ├── mask.lit.nii.gz
+   │   └── orig/
+   │       ├── mask.lit.nii.gz
+   │       ├── inpainting_original_image.lit.nii.gz
+   │       └── inpainting_masked_image.lit.nii.gz
+   └── scripts/
+       └── inpainting_*.lit.png
 
 .. note::
    If the source image was isotropic, the output images will have the same resolution as the input image. The area outside of the lesion mask is preserved, except for robust rescaling of intensity values.

--- a/neurolit/cli.py
+++ b/neurolit/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 from platformdirs import user_data_dir
@@ -16,6 +17,12 @@ def _copy_file(src: Path, dst: Path) -> None:
     if dst.exists():
         dst.unlink()
     shutil.copy2(src, dst)
+
+
+def _copy_if_exists(src: Path, dst: Path) -> None:
+    """Copy ``src`` to ``dst`` when the source exists."""
+    if src.exists():
+        _copy_file(src, dst)
 
 
 def run_lit():
@@ -100,7 +107,6 @@ def run_lit():
 
     out_dir = Path(args.sd).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
-    work_dir = out_dir / "inpainting" if args.fastsurfer_dir else out_dir
 
     # Download checkpoints
     print("Checking/Downloading checkpoints...")
@@ -118,48 +124,105 @@ def run_lit():
             print(f"Error: Required model file not found: {model}")
             sys.exit(1)
 
-    # Run inpainting
-    inpainted_img = work_dir / "inpainting_volumes" / "inpainting_result.nii.gz"
-    if not inpainted_img.exists():
-        print("Running inpainting...")
-
-        inpaint_argv = [
-            "--input_image",
-            str(input_image),
-            "--mask_image",
-            str(mask_image),
-            "--out_dir",
-            str(work_dir),
-            "--checkpoint_axial",
-            str(ckpt_axial),
-            "--checkpoint_sagittal",
-            str(ckpt_sagittal),
-            "--checkpoint_coronal",
-            str(ckpt_coronal),
-            "--dilate",
-            str(args.dilate),
-            "--device",
-            args.device,
-            "--batch_size",
-            str(args.batch_size),
-        ]
-
-        if args.keepgeom:
-            inpaint_argv.append("--keepgeom")
-
-        # Forward any unknown arguments
-        inpaint_argv.extend(unknown)
-
-        inpaint_main(inpaint_argv)
-    else:
-        print(f"Inpainted image already exists: {inpainted_img}")
-
     if args.fastsurfer_dir:
         public_inpainted_img = out_dir / "mri" / "inpainted.lit.nii.gz"
+        processed_mask_img = out_dir / "mri" / "mask.lit.nii.gz"
         public_mask_img = out_dir / "mri" / "orig" / "mask.lit.nii.gz"
-        _copy_file(inpainted_img, public_inpainted_img)
-        _copy_file(mask_image, public_mask_img)
-        print(f"Materialized FastSurfer-compatible outputs in {out_dir / 'mri'}")
+        public_original_img = out_dir / "mri" / "orig" / "inpainting_original_image.lit.nii.gz"
+        public_masked_img = out_dir / "mri" / "orig" / "inpainting_masked_image.lit.nii.gz"
+        public_result_png = out_dir / "scripts" / "inpainting_result.lit.png"
+        public_mask_png = out_dir / "scripts" / "inpainting_mask.lit.png"
+        public_original_png = out_dir / "scripts" / "inpainting_original_image.lit.png"
+        public_masked_png = out_dir / "scripts" / "inpainting_masked_image.lit.png"
+
+        required_outputs = (public_inpainted_img, processed_mask_img, public_mask_img)
+        if all(path.exists() for path in required_outputs):
+            print(f"FastSurfer-compatible outputs already exist in {out_dir}")
+        else:
+            with tempfile.TemporaryDirectory(prefix="lit-inpainting.") as tmpdir:
+                work_dir = Path(tmpdir)
+                inpainted_img = work_dir / "inpainting_volumes" / "inpainting_result.nii.gz"
+                print("Running inpainting...")
+
+                inpaint_argv = [
+                    "--input_image",
+                    str(input_image),
+                    "--mask_image",
+                    str(mask_image),
+                    "--out_dir",
+                    str(work_dir),
+                    "--checkpoint_axial",
+                    str(ckpt_axial),
+                    "--checkpoint_sagittal",
+                    str(ckpt_sagittal),
+                    "--checkpoint_coronal",
+                    str(ckpt_coronal),
+                    "--dilate",
+                    str(args.dilate),
+                    "--device",
+                    args.device,
+                    "--batch_size",
+                    str(args.batch_size),
+                ]
+
+                if args.keepgeom:
+                    inpaint_argv.append("--keepgeom")
+
+                # Forward any unknown arguments
+                inpaint_argv.extend(unknown)
+
+                inpaint_main(inpaint_argv)
+
+                _copy_file(inpainted_img, public_inpainted_img)
+                _copy_file(work_dir / "inpainting_volumes" / "inpainting_mask.nii.gz", processed_mask_img)
+                _copy_file(mask_image, public_mask_img)
+                _copy_if_exists(work_dir / "inpainting_volumes" / "inpainting_original_image.nii.gz", public_original_img)
+                _copy_if_exists(work_dir / "inpainting_volumes" / "inpainting_masked_image.nii.gz", public_masked_img)
+                _copy_if_exists(work_dir / "inpainting_images" / "inpainting_result.png", public_result_png)
+                _copy_if_exists(work_dir / "inpainting_images" / "inpainting_mask.png", public_mask_png)
+                _copy_if_exists(work_dir / "inpainting_images" / "inpainting_original_image.png", public_original_png)
+                _copy_if_exists(work_dir / "inpainting_images" / "inpainting_masked_image.png", public_masked_png)
+
+            print(f"Materialized FastSurfer-compatible outputs in {out_dir}")
+    else:
+        work_dir = out_dir
+        inpainted_img = work_dir / "inpainting_volumes" / "inpainting_result.nii.gz"
+        if not inpainted_img.exists():
+            print("Running inpainting...")
+
+            inpaint_argv = [
+                "--input_image",
+                str(input_image),
+                "--mask_image",
+                str(mask_image),
+                "--out_dir",
+                str(work_dir),
+                "--checkpoint_axial",
+                str(ckpt_axial),
+                "--checkpoint_sagittal",
+                str(ckpt_sagittal),
+                "--checkpoint_coronal",
+                str(ckpt_coronal),
+                "--dilate",
+                str(args.dilate),
+                "--device",
+                args.device,
+                "--batch_size",
+                str(args.batch_size),
+            ]
+
+            if args.keepgeom:
+                inpaint_argv.append("--keepgeom")
+
+            # Forward any unknown arguments
+            inpaint_argv.extend(unknown)
+
+            inpaint_main(inpaint_argv)
+        else:
+            print(f"Inpainted image already exists: {inpainted_img}")
+
+    if args.fastsurfer_dir:
+        print(f"FastSurfer-compatible outputs available in {out_dir / 'mri'} and {out_dir / 'scripts'}")
 
     print("Finished inpainting")
 

--- a/neurolit/cli.py
+++ b/neurolit/cli.py
@@ -4,6 +4,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import nibabel as nib
+import nibabel.processing
 from platformdirs import user_data_dir
 
 from neurolit._version import get_version_with_hash
@@ -23,6 +25,15 @@ def _copy_if_exists(src: Path, dst: Path) -> None:
     """Copy ``src`` to ``dst`` when the source exists."""
     if src.exists():
         _copy_file(src, dst)
+
+
+def _resample_mask_to_reference(src: Path, reference: Path, dst: Path) -> None:
+    """Resample a mask to ``reference`` geometry using nearest-neighbor interpolation."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    mask_img = nib.load(str(src))
+    reference_img = nib.load(str(reference))
+    resampled = nibabel.processing.resample_from_to(mask_img, reference_img, order=0, mode="constant", cval=0)
+    nib.save(nib.Nifti1Image(resampled.get_fdata().astype(mask_img.get_data_dtype()), reference_img.affine, reference_img.header), str(dst))
 
 
 def run_lit():
@@ -174,7 +185,10 @@ def run_lit():
                 inpaint_main(inpaint_argv)
 
                 _copy_file(inpainted_img, public_inpainted_img)
-                _copy_file(work_dir / "inpainting_volumes" / "inpainting_mask.nii.gz", processed_mask_img)
+                if args.keepgeom:
+                    _resample_mask_to_reference(work_dir / "inpainting_volumes" / "inpainting_mask.nii.gz", public_inpainted_img, processed_mask_img)
+                else:
+                    _copy_file(work_dir / "inpainting_volumes" / "inpainting_mask.nii.gz", processed_mask_img)
                 _copy_file(mask_image, public_mask_img)
                 _copy_if_exists(work_dir / "inpainting_volumes" / "inpainting_original_image.nii.gz", public_original_img)
                 _copy_if_exists(work_dir / "inpainting_volumes" / "inpainting_masked_image.nii.gz", public_masked_img)

--- a/neurolit/cli.py
+++ b/neurolit/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import shutil
 import sys
 from pathlib import Path
 
@@ -7,6 +8,14 @@ from platformdirs import user_data_dir
 from neurolit._version import get_version_with_hash
 from neurolit.inpaint_image import main as inpaint_main
 from neurolit.utils.download_checkpoints import main as download_main
+
+
+def _copy_file(src: Path, dst: Path) -> None:
+    """Copy a file to ``dst``, replacing an existing destination if needed."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        dst.unlink()
+    shutil.copy2(src, dst)
 
 
 def run_lit():
@@ -26,6 +35,11 @@ def run_lit():
     # Optional arguments
     parser.add_argument("--dilate", type=int, default=0, help="Number of times to dilate the lesion mask (default: 0)")
     parser.add_argument("--keepgeom", action="store_true", help="Preserve native output geometry")
+    parser.add_argument(
+        "--fastsurfer_dir",
+        action="store_true",
+        help="Treat the output directory as a FastSurfer subject directory and materialize FastSurfer-style outputs",
+    )
     parser.add_argument(
         "--device",
         choices=["auto", "cpu", "cuda"],
@@ -53,6 +67,7 @@ def run_lit():
         print("Optional arguments:")
         print("  --dilate              : Number of times to dilate the lesion mask (default: 0)")
         print("  --keepgeom            : Preserve native output geometry")
+        print("  --fastsurfer_dir      : Treat output_directory as a FastSurfer subject directory")
         print("  --device              : Inference device: auto, cpu, or cuda (default: auto)")
         print("  --batch_size          : Slices per GPU batch (default: 8); reduce to lower GPU memory usage")
         print("Other arguments:")
@@ -85,6 +100,7 @@ def run_lit():
 
     out_dir = Path(args.sd).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
+    work_dir = out_dir / "inpainting" if args.fastsurfer_dir else out_dir
 
     # Download checkpoints
     print("Checking/Downloading checkpoints...")
@@ -103,7 +119,7 @@ def run_lit():
             sys.exit(1)
 
     # Run inpainting
-    inpainted_img = out_dir / "inpainting_volumes" / "inpainting_result.nii.gz"
+    inpainted_img = work_dir / "inpainting_volumes" / "inpainting_result.nii.gz"
     if not inpainted_img.exists():
         print("Running inpainting...")
 
@@ -113,7 +129,7 @@ def run_lit():
             "--mask_image",
             str(mask_image),
             "--out_dir",
-            str(out_dir),
+            str(work_dir),
             "--checkpoint_axial",
             str(ckpt_axial),
             "--checkpoint_sagittal",
@@ -137,6 +153,13 @@ def run_lit():
         inpaint_main(inpaint_argv)
     else:
         print(f"Inpainted image already exists: {inpainted_img}")
+
+    if args.fastsurfer_dir:
+        public_inpainted_img = out_dir / "mri" / "inpainted.lit.nii.gz"
+        public_mask_img = out_dir / "mri" / "orig" / "mask.lit.nii.gz"
+        _copy_file(inpainted_img, public_inpainted_img)
+        _copy_file(mask_image, public_mask_img)
+        print(f"Materialized FastSurfer-compatible outputs in {out_dir / 'mri'}")
 
     print("Finished inpainting")
 

--- a/neurolit/cli.py
+++ b/neurolit/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import nibabel as nib
 import nibabel.processing
+import numpy as np
 from platformdirs import user_data_dir
 
 from neurolit._version import get_version_with_hash
@@ -15,6 +16,10 @@ from neurolit.utils.download_checkpoints import main as download_main
 
 def _copy_file(src: Path, dst: Path) -> None:
     """Copy a file to ``dst``, replacing an existing destination if needed."""
+    src = src.resolve()
+    dst = dst.resolve()
+    if src == dst:
+        return
     dst.parent.mkdir(parents=True, exist_ok=True)
     if dst.exists():
         dst.unlink()
@@ -33,7 +38,11 @@ def _resample_mask_to_reference(src: Path, reference: Path, dst: Path) -> None:
     mask_img = nib.load(str(src))
     reference_img = nib.load(str(reference))
     resampled = nibabel.processing.resample_from_to(mask_img, reference_img, order=0, mode="constant", cval=0)
-    nib.save(nib.Nifti1Image(resampled.get_fdata().astype(mask_img.get_data_dtype()), reference_img.affine, reference_img.header), str(dst))
+    mask_dtype = mask_img.get_data_dtype()
+    mask_data = np.asanyarray(resampled.dataobj).astype(mask_dtype, copy=False)
+    header = reference_img.header.copy()
+    header.set_data_dtype(mask_dtype)
+    nib.save(nib.Nifti1Image(mask_data, reference_img.affine, header), str(dst))
 
 
 def run_lit():
@@ -146,7 +155,17 @@ def run_lit():
         public_original_png = out_dir / "scripts" / "inpainting_original_image.lit.png"
         public_masked_png = out_dir / "scripts" / "inpainting_masked_image.lit.png"
 
-        required_outputs = (public_inpainted_img, processed_mask_img, public_mask_img)
+        required_outputs = (
+            public_inpainted_img,
+            processed_mask_img,
+            public_mask_img,
+            public_original_img,
+            public_masked_img,
+            public_result_png,
+            public_mask_png,
+            public_original_png,
+            public_masked_png,
+        )
         if all(path.exists() for path in required_outputs):
             print(f"FastSurfer-compatible outputs already exist in {out_dir}")
         else:

--- a/neurolit/scripts/lesion_postprocessing.py
+++ b/neurolit/scripts/lesion_postprocessing.py
@@ -292,6 +292,7 @@ def resolve_inpainting_mask_path(subjects_dir: Path, subject_id: str) -> Path:
     """Resolve the lesion mask written by ``lit-inpainting`` for a subject."""
     subject_path = subjects_dir / subject_id
     candidates = [
+        subject_path / "mri" / "mask.lit.nii.gz",
         subject_path / "inpainting" / "inpainting_volumes" / "inpainting_mask.nii.gz",
         # Legacy location used by older FastSurfer integration revisions.
         subject_path / "inpainting" / "inpainting_mask.nii.gz",

--- a/neurolit/scripts/lesion_postprocessing.py
+++ b/neurolit/scripts/lesion_postprocessing.py
@@ -288,6 +288,20 @@ def validate_segstats_installation() -> tuple[Path | None, bool]:
     sys.exit(1)
 
 
+def resolve_inpainting_mask_path(subjects_dir: Path, subject_id: str) -> Path:
+    """Resolve the lesion mask written by ``lit-inpainting`` for a subject."""
+    subject_path = subjects_dir / subject_id
+    candidates = [
+        subject_path / "inpainting" / "inpainting_volumes" / "inpainting_mask.nii.gz",
+        # Legacy location used by older FastSurfer integration revisions.
+        subject_path / "inpainting" / "inpainting_mask.nii.gz",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
 def check_required_files(subjects_dir: Path, subject_id: str, config: dict[str, Any]) -> None:
     """Verify that the essential files exist for a subject before processing.
 
@@ -302,9 +316,7 @@ def check_required_files(subjects_dir: Path, subject_id: str, config: dict[str, 
     """
     logger.info("Checking for required input files...")
     
-    required_files = [
-        subjects_dir / subject_id / "inpainting" / "inpainting_mask.nii.gz",
-    ]
+    required_files = [resolve_inpainting_mask_path(subjects_dir, subject_id)]
     optional_segstats_inputs = [
         subjects_dir / subject_id / "mri" / "orig_nu.mgz",
         subjects_dir / subject_id / "mri" / "norm.mgz",
@@ -488,7 +500,7 @@ def map_lesion_to_segmentation(subjects_dir: Path, subject_id: str,
     """
     input_path = subjects_dir / subject_id / input_file
     output_path = subjects_dir / subject_id / output_file
-    mask_path = subjects_dir / subject_id / "inpainting" / "inpainting_mask.nii.gz"
+    mask_path = resolve_inpainting_mask_path(subjects_dir, subject_id)
     
     if not input_path.exists():
         logger.warning(f"  Skipping: {input_file} not found at {input_path}")
@@ -807,7 +819,7 @@ def surface_masking(lit_path: Path, subjects_dir: Path, subject_id: str,
         Always ``True`` (kept for backwards compatibility).
     """
     insurf = str(subjects_dir / subject_id / "surf" / f"{hemisphere}.pial")
-    inseg = str(subjects_dir / subject_id / "inpainting" / "inpainting_mask.nii.gz")
+    inseg = str(resolve_inpainting_mask_path(subjects_dir, subject_id))
     incort = str(subjects_dir / subject_id / "label" / f"{hemisphere}.cortex.label")
     surflut = str(lit_path / "postprocessing" / "DKTatlaslookup_lesion.txt")
     seglut = str(lit_path / "postprocessing" / "hemi.DKTatlaslookup_lesion.txt")

--- a/neurolit/scripts/lesion_postprocessing.py
+++ b/neurolit/scripts/lesion_postprocessing.py
@@ -289,18 +289,8 @@ def validate_segstats_installation() -> tuple[Path | None, bool]:
 
 
 def resolve_inpainting_mask_path(subjects_dir: Path, subject_id: str) -> Path:
-    """Resolve the lesion mask written by ``lit-inpainting`` for a subject."""
-    subject_path = subjects_dir / subject_id
-    candidates = [
-        subject_path / "mri" / "mask.lit.nii.gz",
-        subject_path / "inpainting" / "inpainting_volumes" / "inpainting_mask.nii.gz",
-        # Legacy location used by older FastSurfer integration revisions.
-        subject_path / "inpainting" / "inpainting_mask.nii.gz",
-    ]
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-    return candidates[0]
+    """Resolve the FastSurfer-mode lesion mask written by ``lit-inpainting``."""
+    return subjects_dir / subject_id / "mri" / "mask.lit.nii.gz"
 
 
 def check_required_files(subjects_dir: Path, subject_id: str, config: dict[str, Any]) -> None:

--- a/neurolit/scripts/run_lit_containerized.sh
+++ b/neurolit/scripts/run_lit_containerized.sh
@@ -271,11 +271,13 @@ if [ "$USE_SINGULARITY" = true ]; then
     exit 1
   fi
 
-  SINGULARITY_ARGS=()
+  # Keep the container isolated from host Python packages and the repo checkout.
+  SINGULARITY_ARGS=(--cleanenv --pwd /tmp)
   if [[ "$RESOLVED_DEVICE" == "cuda" ]]; then
     SINGULARITY_ARGS+=(--nv)
   fi
 
+  SINGULARITYENV_PYTHONNOUSERSITE=1 APPTAINERENV_PYTHONNOUSERSITE=1 \
   $SINGULARITY_CMD exec "${SINGULARITY_ARGS[@]}" \
     -B "${INPUT_IMAGE}":"${INPUT_IMAGE}":ro \
     -B "${MASK_IMAGE}":"${MASK_IMAGE}":ro \

--- a/neurolit/scripts/run_lit_containerized.sh
+++ b/neurolit/scripts/run_lit_containerized.sh
@@ -140,7 +140,7 @@ while [[ $# -gt 0 ]]; do
                     grep -oP '"name":\s*"\K[0-9]+\.[0-9]+\.[0-9]+' | \
                     sort -V | tail -n 1)
         fi
-        [[ -z "$VERSION" ]] && VERSION="0.6.0"
+        [[ -z "$VERSION" ]] && VERSION="0.6.1"
       fi
       hash_file="$PROJ_DIR/git.hash"
       if [[ -n "$(which git)" ]] && (git -C "$PROJ_DIR" rev-parse 2>/dev/null ) ; then
@@ -192,7 +192,7 @@ if [[ -z "$VERSION" ]]; then
               sort -V | tail -n 1)
   fi
   if [[ -z "$VERSION" ]]; then
-    VERSION="0.6.0"
+    VERSION="0.6.1"
   fi
 fi
 

--- a/neurolit/tests/test_cli_help.py
+++ b/neurolit/tests/test_cli_help.py
@@ -86,13 +86,31 @@ def test_lit_inpainting_fastsurfer_dir_materializes_outputs(tmp_path, monkeypatc
 
     def fake_inpaint_main(argv: list[str]) -> None:
         out_dir = Path(argv[argv.index("--out_dir") + 1])
-        assert out_dir == subject_dir / "inpainting"
+        assert out_dir != subject_dir
         volumes_dir = out_dir / "inpainting_volumes"
+        images_dir = out_dir / "inpainting_images"
         volumes_dir.mkdir(parents=True, exist_ok=True)
+        images_dir.mkdir(parents=True, exist_ok=True)
         nib.save(
             nib.Nifti1Image(np.full((4, 4, 4), 7, dtype=np.float32), np.eye(4)),
             volumes_dir / "inpainting_result.nii.gz",
         )
+        nib.save(
+            nib.Nifti1Image(mask_data, np.eye(4)),
+            volumes_dir / "inpainting_mask.nii.gz",
+        )
+        nib.save(
+            nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)),
+            volumes_dir / "inpainting_original_image.nii.gz",
+        )
+        nib.save(
+            nib.Nifti1Image(np.zeros((4, 4, 4), dtype=np.float32), np.eye(4)),
+            volumes_dir / "inpainting_masked_image.nii.gz",
+        )
+        (images_dir / "inpainting_result.png").write_bytes(b"png")
+        (images_dir / "inpainting_mask.png").write_bytes(b"png")
+        (images_dir / "inpainting_original_image.png").write_bytes(b"png")
+        (images_dir / "inpainting_masked_image.png").write_bytes(b"png")
 
     monkeypatch.setattr(cli, "inpaint_main", fake_inpaint_main)
     monkeypatch.setattr(
@@ -113,10 +131,23 @@ def test_lit_inpainting_fastsurfer_dir_materializes_outputs(tmp_path, monkeypatc
     cli.run_lit()
 
     public_result = subject_dir / "mri" / "inpainted.lit.nii.gz"
+    processed_mask = subject_dir / "mri" / "mask.lit.nii.gz"
     public_mask = subject_dir / "mri" / "orig" / "mask.lit.nii.gz"
+    original_image = subject_dir / "mri" / "orig" / "inpainting_original_image.lit.nii.gz"
+    masked_image = subject_dir / "mri" / "orig" / "inpainting_masked_image.lit.nii.gz"
+    result_png = subject_dir / "scripts" / "inpainting_result.lit.png"
     assert public_result.exists()
+    assert processed_mask.exists()
     assert public_mask.exists()
+    assert original_image.exists()
+    assert masked_image.exists()
+    assert result_png.exists()
+    assert not (subject_dir / "inpainting").exists()
     np.testing.assert_allclose(nib.load(str(public_result)).get_fdata(), 7.0)
+    np.testing.assert_allclose(
+        nib.load(str(processed_mask)).get_fdata(),
+        mask_data,
+    )
     np.testing.assert_allclose(
         nib.load(str(public_mask)).get_fdata(),
         nib.load(str(mask_image)).get_fdata(),

--- a/neurolit/tests/test_cli_help.py
+++ b/neurolit/tests/test_cli_help.py
@@ -1,8 +1,12 @@
 import subprocess
 import sys
+from pathlib import Path
 
+import nibabel as nib
+import numpy as np
 import pytest
 
+import neurolit.cli as cli
 from neurolit.inpaint_image import resolve_inference_device
 
 
@@ -23,6 +27,7 @@ def test_lit_inpainting_help():
     # Testing the module directly:
     result = run_help_test("neurolit.cli")
     assert "--keepgeom" in result.stdout
+    assert "--fastsurfer_dir" in result.stdout
     assert "--device" in result.stdout
     assert "auto, cpu, or cuda" in result.stdout
 
@@ -58,3 +63,61 @@ def test_resolve_inference_device_rejects_unavailable_cuda(monkeypatch):
     monkeypatch.setattr("torch.cuda.is_available", lambda: False)
     with pytest.raises(RuntimeError, match="CUDA was requested"):
         resolve_inference_device("cuda")
+
+
+def test_lit_inpainting_fastsurfer_dir_materializes_outputs(tmp_path, monkeypatch):
+    """FastSurfer mode should write public outputs in the subject directory."""
+    input_image = tmp_path / "input.nii.gz"
+    mask_image = tmp_path / "mask.nii.gz"
+    subject_dir = tmp_path / "subject"
+    mask_data = np.zeros((4, 4, 4), dtype=np.float32)
+    mask_data[1:3, 1:3, 1:3] = 1
+    nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)), input_image)
+    nib.save(nib.Nifti1Image(mask_data, np.eye(4)), mask_image)
+
+    user_data_root = tmp_path / "user-data"
+    weights_dir = user_data_root / "weights"
+    weights_dir.mkdir(parents=True)
+    for name in ("model_coronal.pt", "model_axial.pt", "model_sagittal.pt"):
+        (weights_dir / name).write_bytes(b"stub")
+
+    monkeypatch.setattr(cli, "download_main", lambda argv=None: None)
+    monkeypatch.setattr(cli, "user_data_dir", lambda *args, **kwargs: str(user_data_root))
+
+    def fake_inpaint_main(argv: list[str]) -> None:
+        out_dir = Path(argv[argv.index("--out_dir") + 1])
+        assert out_dir == subject_dir / "inpainting"
+        volumes_dir = out_dir / "inpainting_volumes"
+        volumes_dir.mkdir(parents=True, exist_ok=True)
+        nib.save(
+            nib.Nifti1Image(np.full((4, 4, 4), 7, dtype=np.float32), np.eye(4)),
+            volumes_dir / "inpainting_result.nii.gz",
+        )
+
+    monkeypatch.setattr(cli, "inpaint_main", fake_inpaint_main)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lit-inpainting",
+            "--input_image",
+            str(input_image),
+            "--lesion_mask",
+            str(mask_image),
+            "--sd",
+            str(subject_dir),
+            "--fastsurfer_dir",
+        ],
+    )
+
+    cli.run_lit()
+
+    public_result = subject_dir / "mri" / "inpainted.lit.nii.gz"
+    public_mask = subject_dir / "mri" / "orig" / "mask.lit.nii.gz"
+    assert public_result.exists()
+    assert public_mask.exists()
+    np.testing.assert_allclose(nib.load(str(public_result)).get_fdata(), 7.0)
+    np.testing.assert_allclose(
+        nib.load(str(public_mask)).get_fdata(),
+        nib.load(str(mask_image)).get_fdata(),
+    )

--- a/neurolit/tests/test_cli_help.py
+++ b/neurolit/tests/test_cli_help.py
@@ -8,6 +8,7 @@ import pytest
 
 import neurolit.cli as cli
 from neurolit.inpaint_image import resolve_inference_device
+from neurolit.scripts.lesion_postprocessing import resolve_inpainting_mask_path
 
 
 def run_help_test(module_path):
@@ -63,6 +64,20 @@ def test_resolve_inference_device_rejects_unavailable_cuda(monkeypatch):
     monkeypatch.setattr("torch.cuda.is_available", lambda: False)
     with pytest.raises(RuntimeError, match="CUDA was requested"):
         resolve_inference_device("cuda")
+
+
+def test_postprocessing_resolves_fastsurfer_mask_path_only(tmp_path):
+    """Postprocessing should require the FastSurfer-mode public mask path."""
+    subject_id = "subject"
+    subject_dir = tmp_path / subject_id
+    legacy_mask = subject_dir / "inpainting" / "inpainting_volumes" / "inpainting_mask.nii.gz"
+    legacy_mask.parent.mkdir(parents=True)
+    legacy_mask.write_bytes(b"legacy")
+
+    resolved = resolve_inpainting_mask_path(tmp_path, subject_id)
+
+    assert resolved == subject_dir / "mri" / "mask.lit.nii.gz"
+    assert resolved != legacy_mask
 
 
 def test_lit_inpainting_fastsurfer_dir_materializes_outputs(tmp_path, monkeypatch):
@@ -152,3 +167,61 @@ def test_lit_inpainting_fastsurfer_dir_materializes_outputs(tmp_path, monkeypatc
         nib.load(str(public_mask)).get_fdata(),
         nib.load(str(mask_image)).get_fdata(),
     )
+
+
+def test_lit_inpainting_fastsurfer_dir_forwards_keepgeom(tmp_path, monkeypatch):
+    """FastSurfer mode should pass keepgeom through to the inpainting backend."""
+    input_image = tmp_path / "input.nii.gz"
+    mask_image = tmp_path / "mask.nii.gz"
+    subject_dir = tmp_path / "subject"
+    native_affine = np.diag([1.0, 1.0, 1.2, 1.0])
+    native_data = np.ones((4, 4, 3), dtype=np.float32)
+    native_mask = np.zeros((4, 4, 3), dtype=np.float32)
+    native_mask[1:3, 1:3, 1:2] = 1
+    nib.save(nib.Nifti1Image(native_data, native_affine), input_image)
+    nib.save(nib.Nifti1Image(native_mask, native_affine), mask_image)
+
+    user_data_root = tmp_path / "user-data"
+    weights_dir = user_data_root / "weights"
+    weights_dir.mkdir(parents=True)
+    for name in ("model_coronal.pt", "model_axial.pt", "model_sagittal.pt"):
+        (weights_dir / name).write_bytes(b"stub")
+
+    monkeypatch.setattr(cli, "download_main", lambda argv=None: None)
+    monkeypatch.setattr(cli, "user_data_dir", lambda *args, **kwargs: str(user_data_root))
+
+    def fake_inpaint_main(argv: list[str]) -> None:
+        assert "--keepgeom" in argv
+        out_dir = Path(argv[argv.index("--out_dir") + 1])
+        volumes_dir = out_dir / "inpainting_volumes"
+        volumes_dir.mkdir(parents=True, exist_ok=True)
+        nib.save(
+            nib.Nifti1Image(np.full(native_data.shape, 7, dtype=np.float32), native_affine),
+            volumes_dir / "inpainting_result.nii.gz",
+        )
+        conformed_mask = np.zeros((5, 5, 5), dtype=np.float32)
+        conformed_mask[2:4, 2:4, 2:4] = 1
+        nib.save(nib.Nifti1Image(conformed_mask, np.eye(4)), volumes_dir / "inpainting_mask.nii.gz")
+
+    monkeypatch.setattr(cli, "inpaint_main", fake_inpaint_main)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lit-inpainting",
+            "--input_image",
+            str(input_image),
+            "--lesion_mask",
+            str(mask_image),
+            "--sd",
+            str(subject_dir),
+            "--fastsurfer_dir",
+            "--keepgeom",
+        ],
+    )
+
+    cli.run_lit()
+
+    processed_mask = nib.load(str(subject_dir / "mri" / "mask.lit.nii.gz"))
+    assert processed_mask.shape == native_data.shape
+    np.testing.assert_allclose(processed_mask.affine, native_affine)

--- a/neurolit/tests/test_cli_help.py
+++ b/neurolit/tests/test_cli_help.py
@@ -80,6 +80,16 @@ def test_postprocessing_resolves_fastsurfer_mask_path_only(tmp_path):
     assert resolved != legacy_mask
 
 
+def test_copy_file_same_path_is_noop(tmp_path):
+    """Copying a path onto itself should not delete the source."""
+    source = tmp_path / "source.txt"
+    source.write_text("content")
+
+    cli._copy_file(source, source)
+
+    assert source.read_text() == "content"
+
+
 def test_lit_inpainting_fastsurfer_dir_materializes_outputs(tmp_path, monkeypatch):
     """FastSurfer mode should write public outputs in the subject directory."""
     input_image = tmp_path / "input.nii.gz"
@@ -199,7 +209,7 @@ def test_lit_inpainting_fastsurfer_dir_forwards_keepgeom(tmp_path, monkeypatch):
             nib.Nifti1Image(np.full(native_data.shape, 7, dtype=np.float32), native_affine),
             volumes_dir / "inpainting_result.nii.gz",
         )
-        conformed_mask = np.zeros((5, 5, 5), dtype=np.float32)
+        conformed_mask = np.zeros((5, 5, 5), dtype=np.uint8)
         conformed_mask[2:4, 2:4, 2:4] = 1
         nib.save(nib.Nifti1Image(conformed_mask, np.eye(4)), volumes_dir / "inpainting_mask.nii.gz")
 
@@ -224,4 +234,75 @@ def test_lit_inpainting_fastsurfer_dir_forwards_keepgeom(tmp_path, monkeypatch):
 
     processed_mask = nib.load(str(subject_dir / "mri" / "mask.lit.nii.gz"))
     assert processed_mask.shape == native_data.shape
+    assert np.dtype(processed_mask.get_data_dtype()) == np.dtype(np.uint8)
     np.testing.assert_allclose(processed_mask.affine, native_affine)
+
+
+def test_lit_inpainting_fastsurfer_dir_reruns_when_public_outputs_are_partial(tmp_path, monkeypatch):
+    """FastSurfer mode should not skip when only the core public outputs exist."""
+    input_image = tmp_path / "input.nii.gz"
+    subject_dir = tmp_path / "subject"
+    mask_image = subject_dir / "mri" / "orig" / "mask.lit.nii.gz"
+    public_result = subject_dir / "mri" / "inpainted.lit.nii.gz"
+    processed_mask = subject_dir / "mri" / "mask.lit.nii.gz"
+    original_image = subject_dir / "mri" / "orig" / "inpainting_original_image.lit.nii.gz"
+    masked_image = subject_dir / "mri" / "orig" / "inpainting_masked_image.lit.nii.gz"
+    result_png = subject_dir / "scripts" / "inpainting_result.lit.png"
+    mask_png = subject_dir / "scripts" / "inpainting_mask.lit.png"
+    original_png = subject_dir / "scripts" / "inpainting_original_image.lit.png"
+    masked_png = subject_dir / "scripts" / "inpainting_masked_image.lit.png"
+
+    subject_dir.joinpath("mri", "orig").mkdir(parents=True)
+    nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)), input_image)
+    nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)), mask_image)
+    nib.save(nib.Nifti1Image(np.full((4, 4, 4), 3, dtype=np.float32), np.eye(4)), public_result)
+    nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)), processed_mask)
+
+    user_data_root = tmp_path / "user-data"
+    weights_dir = user_data_root / "weights"
+    weights_dir.mkdir(parents=True)
+    for name in ("model_coronal.pt", "model_axial.pt", "model_sagittal.pt"):
+        (weights_dir / name).write_bytes(b"stub")
+
+    monkeypatch.setattr(cli, "download_main", lambda argv=None: None)
+    monkeypatch.setattr(cli, "user_data_dir", lambda *args, **kwargs: str(user_data_root))
+    calls = []
+
+    def fake_inpaint_main(argv: list[str]) -> None:
+        calls.append(argv)
+        out_dir = Path(argv[argv.index("--out_dir") + 1])
+        volumes_dir = out_dir / "inpainting_volumes"
+        images_dir = out_dir / "inpainting_images"
+        volumes_dir.mkdir(parents=True, exist_ok=True)
+        images_dir.mkdir(parents=True, exist_ok=True)
+        nib.save(nib.Nifti1Image(np.full((4, 4, 4), 7, dtype=np.float32), np.eye(4)), volumes_dir / "inpainting_result.nii.gz")
+        nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)), volumes_dir / "inpainting_mask.nii.gz")
+        nib.save(nib.Nifti1Image(np.ones((4, 4, 4), dtype=np.float32), np.eye(4)), volumes_dir / "inpainting_original_image.nii.gz")
+        nib.save(nib.Nifti1Image(np.zeros((4, 4, 4), dtype=np.float32), np.eye(4)), volumes_dir / "inpainting_masked_image.nii.gz")
+        (images_dir / "inpainting_result.png").write_bytes(b"result")
+        (images_dir / "inpainting_mask.png").write_bytes(b"mask")
+        (images_dir / "inpainting_original_image.png").write_bytes(b"original")
+        (images_dir / "inpainting_masked_image.png").write_bytes(b"masked")
+
+    monkeypatch.setattr(cli, "inpaint_main", fake_inpaint_main)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lit-inpainting",
+            "--input_image",
+            str(input_image),
+            "--lesion_mask",
+            str(mask_image),
+            "--sd",
+            str(subject_dir),
+            "--fastsurfer_dir",
+        ],
+    )
+
+    cli.run_lit()
+
+    assert len(calls) == 1
+    for path in (public_result, processed_mask, mask_image, original_image, masked_image, result_png, mask_png, original_png, masked_png):
+        assert path.exists()
+    np.testing.assert_allclose(nib.load(str(public_result)).get_fdata(), 7.0)

--- a/neurolit/tests/test_inpaint_preprocessing.py
+++ b/neurolit/tests/test_inpaint_preprocessing.py
@@ -1,0 +1,31 @@
+import nibabel as nib
+import numpy as np
+import pytest
+
+from neurolit.inpaint_image import conform_nifti
+
+
+def _make_lia_image(dtype, shape=(32, 32, 32), zooms=(1.0, 1.0, 1.0)):
+    rng = np.random.default_rng(5)
+    ras_data = rng.normal(loc=100.0, scale=20.0, size=shape).astype(dtype)
+    ras_affine = np.diag([zooms[0], zooms[1], zooms[2], 1.0])
+
+    ras_ornt = nib.orientations.axcodes2ornt(("R", "A", "S"))
+    lia_ornt = nib.orientations.axcodes2ornt(("L", "I", "A"))
+    transform = nib.orientations.ornt_transform(ras_ornt, lia_ornt)
+
+    data = nib.orientations.apply_orientation(ras_data, transform)
+    affine = ras_affine @ nib.orientations.inv_ornt_aff(transform, ras_data.shape)
+    return nib.Nifti1Image(data, affine)
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int16])
+def test_conform_nifti_reconforms_non_uint8_lia_inputs(dtype):
+    image = _make_lia_image(dtype)
+
+    output = conform_nifti(image)
+
+    assert output is not image
+    assert output.shape[:3] == image.shape[:3]
+    assert nib.orientations.aff2axcodes(output.affine) == ("L", "I", "A")
+    assert np.dtype(output.get_data_dtype()) == np.dtype(np.uint8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurolit"
-version = "0.7.0-dev"
+version = "0.6.1"
 description = "Lesion Inpainting Tool"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Body

  ## Summary

  This prepares neurolit `0.6.1` for the FastSurfer LIT integration.

  Changes include:

  - set package version to `0.6.1`
  - add FastSurfer-compatible output mode via `--fastsurfer_dir`
  - write FastSurfer-mode outputs directly into the subject directory:
    - `mri/inpainted.lit.nii.gz`
    - `mri/mask.lit.nii.gz`
    - `mri/orig/mask.lit.nii.gz`
  - preserve native geometry for FastSurfer-mode mask outputs when `--keepgeom` is used
  - update lesion postprocessing to consume the public FastSurfer mask path
  - add regression tests for the FastSurfer output contract

  ## Release Testing

  Tested with the release suite against FastSurfer PR #803:

  - clean wheel build and install from `neurolit-0.6.1`
  - standalone clean-wheel inpainting smoke test
  - standalone container test
  - FastSurfer full integration test
  - FastSurfer full integration test with `--no_biasfield`
  - FastSurfer `--keepgeom` anisotropic image test
  - FastSurfer no-inpainting default-pipeline regression

  The anisotropic `--keepgeom` test preserved image geometry:

  - input: `(256, 256, 214)`, voxel size `(1.0, 1.0, 1.2)`
  - `mri/inpainted.lit.nii.gz`: `(256, 256, 214)`, voxel size `(1.0, 1.0, 1.2)`
  - `mri/mask.lit.nii.gz`: `(256, 256, 214)`, voxel size `(1.0, 1.0, 1.2)`

  ## Notes

  This PR is intended to be paired with the FastSurfer LIT integration PR and should be released as `neurolit==0.6.1`
  before FastSurfer depends on `neurolit>=0.6.1`.